### PR TITLE
Do not override existing epilog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+package-lock.json
 lib

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
     grunt.initConfig({
         eslint: {
             options: {
-                configFile: "eslint.yaml"
+                overrideConfigFile: "eslint.yaml"
             },
             "json-asty": [ "src/**/*.js", "tst/**/*.js" ]
         },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "keywords":    [ "json", "ast", "parse", "generate" ],
     "browser":     "./lib/json-asty.browser.js",
     "main":        "./lib/json-asty.node.js",
+    "typings":     "./src/json-asty.d.ts",
     "repository": {
         "type": "git",
         "url":  "https://github.com/rse/json-asty.git"
@@ -21,14 +22,14 @@
         "asty-astq":                                 "1.13.4",
         "pegjs-otf":                                 "1.2.18",
         "pegjs-util":                                "1.4.21",
-        "chalk":                                     "4.1.0"
+        "chalk":                                     "4.1.2"
     },
     "devDependencies": {
-        "grunt":                                     "1.3.0",
-        "grunt-cli":                                 "1.3.2",
+        "grunt":                                     "1.4.1",
+        "grunt-cli":                                 "1.4.3",
         "grunt-contrib-clean":                       "2.0.0",
         "grunt-contrib-watch":                       "1.1.0",
-        "grunt-eslint":                              "23.0.0",
+        "grunt-eslint":                              "24.0.0",
         "grunt-browserify":                          "6.0.0",
         "grunt-mocha-test":                          "0.13.3",
         "browserify":                                "17.0.0",
@@ -39,15 +40,15 @@
         "browserify-header":                         "1.1.0",
         "browserify-derequire":                      "1.1.1",
         "eslint":                                    "7.21.0",
-        "eslint-config-standard":                    "16.0.2",
-        "eslint-plugin-promise":                     "4.3.1",
-        "eslint-plugin-import":                      "2.22.1",
+        "eslint-config-standard":                    "16.0.3",
+        "eslint-plugin-promise":                     "5.1.1",
+        "eslint-plugin-import":                      "2.25.2",
         "eslint-plugin-node":                        "11.1.0",
-        "@babel/core":                               "7.13.10",
-        "@babel/preset-env":                         "7.13.10",
-        "@babel/plugin-transform-runtime":           "7.13.10",
-        "mocha":                                     "8.3.1",
-        "chai":                                      "4.3.3"
+        "@babel/core":                               "7.16.0",
+        "@babel/preset-env":                         "7.16.0",
+        "@babel/plugin-transform-runtime":           "7.16.0",
+        "mocha":                                     "9.1.3",
+        "chai":                                      "4.3.4"
     },
     "scripts": {
         "prepublishOnly":  "grunt default",

--- a/src/json-asty.d.ts
+++ b/src/json-asty.d.ts
@@ -21,18 +21,15 @@
 **  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 **  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
+declare class JsonAsty {
+    /*  parse JSON into AST  */
+    static parse(json: string): object;
 
-declare module "JsonAsty" {
-    class JsonAsty {
-        /*  parse JSON into AST  */
-        static parse(json: string): object;
+    /*  dump AST  */
+    static dump(ast: object, options?: { colors?: boolean }): string;
 
-        /*  dump AST  */
-        static dump(ast: object, options?: { colors?: boolean }): string;
-
-        /*  unparse AST into JSON  */
-        static unparse(ast: object): string;
-    }
-    export = JsonAsty
+    /*  unparse AST into JSON  */
+    static unparse(ast: object): string;
 }
 
+export = JsonAsty

--- a/src/json-asty.pegjs
+++ b/src/json-asty.pegjs
@@ -54,7 +54,8 @@ valueObject
                 member
             )* {
                 return tail.reduce((memo, curr) => {
-                    memo[memo.length - 1].set({ epilog: curr[0] })
+                    var prevNode = memo[memo.length - 1];
+                    prevNode.set({ epilog: (prevNode.get("epilog") || "") + curr[0] })
                     return memo.concat([ curr[1] ])
                 }, [ head ])
             }
@@ -83,7 +84,8 @@ valueArray
                 value /* RECURSION */
             )* {
                 return tail.reduce((memo, curr) => {
-                    memo[memo.length - 1].set({ epilog: curr[0] })
+                    var prevNode = memo[memo.length - 1];
+                    prevNode.set({ epilog: (prevNode.get("epilog") || "") + curr[0] })
                     return memo.concat([ curr[1] ])
                 }, [ head ])
             }

--- a/tst/json-asty.js
+++ b/tst/json-asty.js
@@ -40,6 +40,7 @@ describe("JSON-ASTy Library", () => {
             "true", "false", "null",
             "42", "42.7", "42.7e-10",
             '"foo"', '"foo bar"', '"foo\\"bar"',
+            '[ { "a": "foo"}, {"a": 42}, {"a": 42.7}, {"a": true} ]',
             '[ "foo", 42, 42.7, true ]',
             '{ "foo": "foo", "bar": 42, "baz": 42.7, "quux": true }',
             '{ "foo": { "bar": [ "baz", "quux" ] } }'

--- a/tst/json-asty.js
+++ b/tst/json-asty.js
@@ -40,8 +40,9 @@ describe("JSON-ASTy Library", () => {
             "true", "false", "null",
             "42", "42.7", "42.7e-10",
             '"foo"', '"foo bar"', '"foo\\"bar"',
-            '[ { "a": "foo"}, {"a": 42}, {"a": 42.7}, {"a": true} ]',
             '[ "foo", 42, 42.7, true ]',
+            '[ { "a": "foo"}, {"a": 42}, {"a": 42.7}, {"a": true} ]',
+            '[ { "a": "foo"}, 42, 42.7, {"a": 42}, {"a": 42.7}, {"a": true} ]',
             '{ "foo": "foo", "bar": 42, "baz": 42.7, "quux": true }',
             '{ "foo": { "bar": [ "baz", "quux" ] } }'
         ]


### PR DESCRIPTION
Fixes #1.

Current parser overrides existing epilog for previous node (if any). Added fix to keep existing epilog and instead we just append current char.

Also updated dependencies and `typings` field to `package.json`.